### PR TITLE
README: link to MDN regarding font size values

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Sets the font size for the selected text.
 
 This method takes one argument:
 
-* **size**: A size to set. Any CSS size value is accepted, e.g. '13px', or 'small'.
+* **size**: A size to set. Any CSS [length value](https://developer.mozilla.org/en-US/docs/Web/CSS/length) or [absolute-size value](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_values_syntax#syntax-absolute-size) is accepted, e.g. '13px', or 'small'.
 
 Returns self (the Squire instance).
 


### PR DESCRIPTION
There doesn't seem to be a concept of "size value" per se in CSS.
Based on the two examples given, I went with "length value" and "absolute-size value".
Technically, [the `font-size` property](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size) additionally allows percentages and the "relative-size" values of `larger` or `smaller`. Not sure whether the exclusion of these from the examples was deliberate or not.