### PR TITLE
fix bug on Browserify component when embed in multi layers of iframe 

### DIFF
--- a/source/outro.js
+++ b/source/outro.js
@@ -1,14 +1,14 @@
 /*jshint ignore:start */
 
-if ( top !== win ) {
-    win.editor = new Squire( doc );
-    if ( win.onEditorLoad ) {
-        win.onEditorLoad( win.editor );
-        win.onEditorLoad = null;
-    }
+if ( typeof exports === 'object' ) {
+    module.exports = Squire;
 } else {
-    if ( typeof exports === 'object' ) {
-        module.exports = Squire;
+    if ( top !== win ) {
+        win.editor = new Squire( doc );
+        if ( win.onEditorLoad ) {
+            win.onEditorLoad( win.editor );
+            win.onEditorLoad = null;
+        }
     } else {
         win.Squire = Squire;
     }


### PR DESCRIPTION
**Issue**

When bundle with `browserify`, `Squire` initialize editor on the containing window when we have `Squire` embed on multi layer of `iframe` (project expected behavior, but when bundle with `browserify`, it will be an unexpected behavior)

**Solution**

Move the `exports` check out of the `outro.js`, so when bundle with `browserify` it will export Squire always