### PR TITLE
Change name in bower.json to 'squire-rte'

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Squire",
+  "name": "squire-rte",
   "homepage": "https://github.com/neilj/Squire",
   "authors": [
     "Neil Jenkins <neil@nmjenkins.com>"


### PR DESCRIPTION
Changed `name` in `bower.json` to match the one used for the package in bower's registry, as recommended [here](https://github.com/bower/spec/blob/master/json.md#name).