### PR TITLE
Restore copy/cut function on iOS

### DIFF
--- a/build/squire-raw.js
+++ b/build/squire-raw.js
@@ -1989,7 +1989,7 @@ var onCut = function ( event ) {
     this.saveUndoState( range );
 
     // Edge only seems to support setting plain text as of 2016-03-11.
-    if ( !isEdge && clipboardData ) {
+    if ( !isEdge && !isIOS && clipboardData ) {
         moveRangeBoundariesUpTree( range, body );
         node.appendChild( deleteContentsOfRange( range, body ) );
         clipboardData.setData( 'text/html', node.innerHTML );
@@ -2016,7 +2016,7 @@ var onCopy = function ( event ) {
     var node = this.createElement( 'div' );
 
     // Edge only seems to support setting plain text as of 2016-03-11.
-    if ( !isEdge && clipboardData ) {
+    if ( !isEdge && !isIOS && clipboardData ) {
         node.appendChild( range.cloneContents() );
         clipboardData.setData( 'text/html', node.innerHTML );
         clipboardData.setData( 'text/plain',


### PR DESCRIPTION
The recent changes to how copy and cut work seem to prevent them from working on iOS. Manipulating the clipboard data in javascript on iOS empties the clipboard instead of replacing it. Preventing the default prevents iOS from intervening and placing the expected information on the clipboard.

I've added a check for !iOS, much like the current check for Edge, so we skip that part of the copy/cut functions. This should leave the new changes in place for other platforms/browsers.