### PR TITLE
Fix tests that call selectAll

### DIFF
--- a/test/squire.spec.js
+++ b/test/squire.spec.js
@@ -26,6 +26,7 @@ describe('Squire RTE', function () {
     });
 
     function selectAll(editor) {
+        doc.getSelection().removeAllRanges()
         var range = doc.createRange();
         range.setStart(doc.body.childNodes.item(0), 0);
         range.setEnd(doc.body.childNodes.item(0), doc.body.childNodes.item(0).childNodes.length);


### PR DESCRIPTION
`editor.getSelection())` goes down different code paths depending on if the document has a selection or not. This was causing tests to fail -- this change resets the selection whenever `selectAll` is called.