### PR TITLE
fix: handle insert table by CF_HTML

### DIFF
--- a/source/Editor.js
+++ b/source/Editor.js
@@ -1749,6 +1749,14 @@ proto.insertHTML = function ( html, isPaste ) {
         }
         // Parse HTML into DOM tree
         div = this.createElement( 'DIV' );
+        // wrap with tr if html contains dangling td tags
+        if (html.match(/<\/td>((?!<\/tr>)[\s\S])*$/i)) {
+            html = '<TR>' + html + '</TR>';
+        }
+        // wrap with table if html contains dangling tr tags
+        if (html.match(/<\/tr>((?!<\/table>)[\s\S])*$/i)) {
+            html = '<TABLE>' + html + '</TABLE>';
+        } 
         div.innerHTML = html;
         frag = doc.createDocumentFragment();
         frag.appendChild( empty( div ) );

--- a/test/squire.spec.js
+++ b/test/squire.spec.js
@@ -351,6 +351,18 @@ describe('Squire RTE', function () {
       })
     });
 
+    describe('insertHTML', function() {
+        it('fix CF_HTML incomplete table', function() {
+            editor.insertHTML('<table><tbody><tr><!--StartFragment--><td>text</td><!--EndFragment--></tr></tbody></table>');
+            expect(editor.getHTML(), 'to contain', '<table><tbody><tr><td>text<br></td></tr></tbody></table>');
+
+            editor.setHTML('');
+
+            editor.insertHTML('<table><tbody><!--StartFragment--><tr><td>text1</td><td>text2</td></tr><!--EndFragment--></tbody></table>');
+            expect(editor.getHTML(), 'to contain', '<table><tbody><tr><td>text1<br></td><td>text2<br></td></tr></tbody></table>');
+        });
+    });
+
     afterEach(function () {
         editor = null;
         var iframe = document.getElementById('testFrame');


### PR DESCRIPTION
ms html clipboard format CF_HTML handles table like below if we copy part of table.
It makes dangling tr, td without table tag when pasting copied table from ms product such as ie, excel, powerpoint.
```html
<TABLE BORDER>
<!--StartFragment-->
<TR><TD>Item 6</TD><TD>Item 7</TD></TR><TR><TD>Item 10</TD><TD>Item 11</TD></TR>
<!--EndFragment-->
</TABLE>
```
and
```html
<TABLE BORDER><TR>
<!--StartFragment-->
<TD>Item</TD>
<!--EndFragment-->
</TR></TABLE>
```
https://msdn.microsoft.com/en-us/library/windows/desktop/ms649015(v=vs.85).aspx

#274