### PR TITLE
feat: configurate inlineNodeNames and allowBlock

### DIFF
--- a/source/Clean.js
+++ b/source/Clean.js
@@ -179,9 +179,7 @@ var stylesRewriters = {
     }
 };
 
-var allowedBlock = {
-    regexp: /^(?:A(?:DDRESS|RTICLE|SIDE|UDIO)|BLOCKQUOTE|CAPTION|D(?:[DLT]|IV)|F(?:IGURE|IGCAPTION|OOTER)|H[1-6]|HEADER|L(?:ABEL|EGEND|I)|O(?:L|UTPUT)|P(?:RE)?|SECTION|T(?:ABLE|BODY|D|FOOT|H|HEAD|R)|COL(?:GROUP)?|UL)$/
-};
+var allowedBlock = /^(?:A(?:DDRESS|RTICLE|SIDE|UDIO)|BLOCKQUOTE|CAPTION|D(?:[DLT]|IV)|F(?:IGURE|IGCAPTION|OOTER)|H[1-6]|HEADER|L(?:ABEL|EGEND|I)|O(?:L|UTPUT)|P(?:RE)?|SECTION|T(?:ABLE|BODY|D|FOOT|H|HEAD|R)|COL(?:GROUP)?|UL)$/;
 
 var blacklist = /^(?:HEAD|META|STYLE)/;
 
@@ -219,7 +217,7 @@ var cleanTree = function cleanTree ( node, config, preserveWS ) {
                 i -= 1;
                 l -= 1;
                 continue;
-            } else if ( !allowedBlock.regexp.test( nodeName ) && !isInline( child ) ) {
+            } else if ( !config.allowedBlock.test( nodeName ) && !isInline( child ) ) {
                 i -= 1;
                 l += childLength - 1;
                 node.replaceChild( empty( child ), child );

--- a/source/Clean.js
+++ b/source/Clean.js
@@ -179,7 +179,9 @@ var stylesRewriters = {
     }
 };
 
-var allowedBlock = /^(?:A(?:DDRESS|RTICLE|SIDE|UDIO)|BLOCKQUOTE|CAPTION|D(?:[DLT]|IV)|F(?:IGURE|IGCAPTION|OOTER)|H[1-6]|HEADER|L(?:ABEL|EGEND|I)|O(?:L|UTPUT)|P(?:RE)?|SECTION|T(?:ABLE|BODY|D|FOOT|H|HEAD|R)|COL(?:GROUP)?|UL)$/;
+var allowedBlock = {
+    regexp: /^(?:A(?:DDRESS|RTICLE|SIDE|UDIO)|BLOCKQUOTE|CAPTION|D(?:[DLT]|IV)|F(?:IGURE|IGCAPTION|OOTER)|H[1-6]|HEADER|L(?:ABEL|EGEND|I)|O(?:L|UTPUT)|P(?:RE)?|SECTION|T(?:ABLE|BODY|D|FOOT|H|HEAD|R)|COL(?:GROUP)?|UL)$/
+};
 
 var blacklist = /^(?:HEAD|META|STYLE)/;
 
@@ -217,7 +219,7 @@ var cleanTree = function cleanTree ( node, config, preserveWS ) {
                 i -= 1;
                 l -= 1;
                 continue;
-            } else if ( !allowedBlock.test( nodeName ) && !isInline( child ) ) {
+            } else if ( !allowedBlock.regexp.test( nodeName ) && !isInline( child ) ) {
                 i -= 1;
                 l += childLength - 1;
                 node.replaceChild( empty( child ), child );

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -178,6 +178,7 @@ proto.setConfig = function ( config ) {
             highlight: 'highlight'
         },
         leafNodeNames: leafNodeNames,
+        inlineNodeNames: inlineNodeNames,
         undo: {
             documentSizeThreshold: -1, // -1 means no threshold
             undoLimit: -1 // -1 means no limit

--- a/source/Editor.js
+++ b/source/Editor.js
@@ -179,6 +179,7 @@ proto.setConfig = function ( config ) {
         },
         leafNodeNames: leafNodeNames,
         inlineNodeNames: inlineNodeNames,
+        allowedBlock: allowedBlock,
         undo: {
             documentSizeThreshold: -1, // -1 means no threshold
             undoLimit: -1 // -1 means no limit

--- a/source/Node.js
+++ b/source/Node.js
@@ -1,6 +1,8 @@
 /*jshint strict:false, undef:false, unused:false */
 
-var inlineNodeNames  = /^(?:#text|A(?:BBR|CRONYM)?|B(?:R|D[IO])?|C(?:ITE|ODE)|D(?:ATA|EL|FN)|EM|FONT|HR|I(?:FRAME|MG|NPUT|NS)?|KBD|Q|R(?:P|T|UBY)|S(?:AMP|MALL|PAN|TR(?:IKE|ONG)|U[BP])?|TIME|U|VAR|WBR)$/;
+var inlineNodeNames  = {
+    regexp: /^(?:#text|A(?:BBR|CRONYM)?|B(?:R|D[IO])?|C(?:ITE|ODE)|D(?:ATA|EL|FN)|EM|FONT|HR|I(?:FRAME|MG|NPUT|NS)?|KBD|Q|R(?:P|T|UBY)|S(?:AMP|MALL|PAN|TR(?:IKE|ONG)|U[BP])?|TIME|U|VAR|WBR)$/
+};
 
 var leafNodeNames = {
     BR: 1,
@@ -51,7 +53,7 @@ function getNodeCategory ( node ) {
         // Malformed HTML can have block tags inside inline tags. Need to treat
         // these as containers rather than inline. See #239.
         nodeCategory = CONTAINER;
-    } else if ( inlineNodeNames.test( node.nodeName ) ) {
+    } else if ( inlineNodeNames.regexp.test( node.nodeName ) ) {
         nodeCategory = INLINE;
     } else {
         nodeCategory = BLOCK;


### PR DESCRIPTION
We want to change `inlineNodeNames` because some block-level nodes is wrapped `<div>` in `fixContainer`. For example we don't want to wrap `<hr>` by `<div>`.  If `inlineNodeNames` is added to the configuration, it seems to be easier to use. :)