### PR TITLE
docs: Fix simple typo, unfocussable -> unfocusable

### DIFF
--- a/build/squire-raw.js
+++ b/build/squire-raw.js
@@ -392,7 +392,7 @@ function createElement ( doc, tag, props, children ) {
 
 function fixCursor ( node, root ) {
     // In Webkit and Gecko, block level elements are collapsed and
-    // unfocussable if they have no content. To remedy this, a <BR> must be
+    // unfocusable if they have no content. To remedy this, a <BR> must be
     // inserted. In Opera and IE, we just need a textnode in order for the
     // cursor to appear.
     var self = root.__squire__;

--- a/source/Node.js
+++ b/source/Node.js
@@ -225,7 +225,7 @@ function createElement ( doc, tag, props, children ) {
 
 function fixCursor ( node, root ) {
     // In Webkit and Gecko, block level elements are collapsed and
-    // unfocussable if they have no content. To remedy this, a <BR> must be
+    // unfocusable if they have no content. To remedy this, a <BR> must be
     // inserted. In Opera and IE, we just need a textnode in order for the
     // cursor to appear.
     var self = root.__squire__;


### PR DESCRIPTION
There is a small typo in build/squire-raw.js, source/Node.js.

Should read `unfocusable` rather than `unfocussable`.

