### PR TITLE
isOrContains use Node.contains

### DIFF
--- a/source/Node.js
+++ b/source/Node.js
@@ -120,13 +120,7 @@ function getNearest ( node, root, tag, attributes ) {
     return null;
 }
 function isOrContains ( parent, node ) {
-    while ( node ) {
-        if ( node === parent ) {
-            return true;
-        }
-        node = node.parentNode;
-    }
-    return false;
+    return parent.contains(node);
 }
 
 function getPath ( node, root, config ) {

--- a/source/Node.js
+++ b/source/Node.js
@@ -120,7 +120,7 @@ function getNearest ( node, root, tag, attributes ) {
     return null;
 }
 function isOrContains ( parent, node ) {
-    return parent.contains(node);
+    return parent.contains( node );
 }
 
 function getPath ( node, root, config ) {


### PR DESCRIPTION
isOrContains travels throught the nodes the old way.
These days we have Node.contains (even in IE9+)
https://developer.mozilla.org/en-US/docs/Web/API/Node/contains