### PR TITLE
Do not publish unnecessary files to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,5 @@ Makefile
 .editorconfig
 bower.json
 source/
+test/
+Demo.html


### PR DESCRIPTION
For the sake of a smaller npm package, do not publish unnecessary files to npm registry.