### PR TITLE
Add CI to GitHub

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ insert_final_newline = true
 charset = utf-8
 indent_style = space
 indent_size = 4
+
+[*.yaml]
+indent_size = 2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,35 @@
+name: "🧪 Test"
+
+on:
+  pull_request: null
+  push:
+    branches:
+      - "master"
+
+permissions:
+  contents: "read"
+
+env:
+  NODE_VERSION: "24"
+
+jobs:
+  test:
+    runs-on: "ubuntu-24.04"
+    steps:
+      - name: "Checkout the repo"
+        uses: "actions/checkout@v6"
+        with:
+          persist-credentials: "false"
+
+      - name: "Setup node"
+        uses: "actions/setup-node@v6"
+        with:
+          node-version: "${{ env.NODE_VERSION }}"
+
+      - name: "Install dependencies"
+        run: |
+          npm ci --ignore-scripts
+
+      - name: "Run tests"
+        run: |
+          npm run test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,0 @@
-test:
-  stage: test
-  script: npm ci --ignore-scripts --force && npm run test
-  only:
-    - merge_requests


### PR DESCRIPTION
This introduces the following changes:

* Run the test suite in GitHub CI.
* Standardize YAML files on 2-space indentation.
* Remove the GitLab CI file.

The test suite currently fails, and flagging this in CI is an important step to resolving these failures and keeping them resolved.

There is [an example of a CI run](https://github.com/kurtmckee/pr-fastmail-squire/actions/runs/26101865810/job/76754797144) in my repo fork.

> [!NOTE]
>
> To fix the failing tests, I don't know if the test suite needs to be updated to match current behavior, or if the code needs to be updated to match test suite expectations.
>
> If it's desirable to fix the failing tests before this merges, I would need direction as to whether the _code_ needs to be fixed, or if the _tests_ need to be updated. I don't have much experience with TypeScript, but at the very least I can use `git bisect` to find the commits where each test started to fail.